### PR TITLE
Pinning babel__traverse to avoid a build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "homepage": "./",
   "private": true,
   "dependencies": {
+    "@types/babel__traverse": "7.14.2",
     "@stomp/stompjs": "^5.4.4",
     "@types/crypto-js": "^4.0.2",
     "@types/google-protobuf": "3.7.2",


### PR DESCRIPTION
Currently building with Docker seems to fail with an error like this:

```
/usr/local/bin/node /app/scripts/generate-build.js 4.0.0
Current build number: 193
Creating an optimized production build...
Failed to compile.

/app/node_modules/@types/babel__traverse/index.d.ts
TypeScript error in /app/node_modules/@types/babel__traverse/index.d.ts(68,50):
']' expected.  TS1005

    66 | }
    67 |
  > 68 | export type ArrayKeys<T> = keyof { [P in keyof T as T[P] extends any[] ? P : never]: P };
       |                                                  ^
    69 |
    70 | export class Scope {
    71 |     constructor(path: NodePath, parentScope?: Scope);


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! woz@4.0.0 build: `node scripts/generate-build.js ${npm_package_version} && react-scripts build && rm -rf dist && mkdir -p dist && mv build dist/woz`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the woz@4.0.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```

The same thing happened with the chat interface in TaskMAD. In that case I'd just fixed it by pinning the version of the `babel__traverse` package to `7.14.2`, doing the same thing also seems to work for this app. 
